### PR TITLE
Improve lit cells calculation

### DIFF
--- a/Scenes/Levels/Game.gd
+++ b/Scenes/Levels/Game.gd
@@ -1,14 +1,18 @@
 extends Node2D
 
-signal cells_lit_status_updated(new_cells_lit_status: Dictionary)
+# Signals
+signal lit_cells_updated(new_lit_cells: Dictionary)
 
-@onready var tile_map: WorldTileMap = $WorldTileMap
-@onready var player: CharacterBody2D = $Player
-
+# Consts
 var light_group := "light"
 var darkness_layer := 1
 
-var cells_lit_status: Dictionary = {}
+# Node references
+@onready var tile_map: WorldTileMap = $WorldTileMap
+@onready var player: CharacterBody2D = $Player
+
+# Variables
+var lit_cells: Dictionary = {}
 var player_tile_coords: Vector2i
 
 func _ready() -> void:
@@ -25,21 +29,18 @@ func _process(_delta: float) -> void:
 	
 func prepare_new_turn() -> void:
 	# TODO: remove extinguished light sources
-	calculate_lit_tiles()
-	emit_signal("cells_lit_status_updated", cells_lit_status)
+	calculate_lit_cells()
 	
-func calculate_lit_tiles() -> void:
-	for x_index in range(tile_map.top_left_tile_coords.x, tile_map.bottom_right_tile_coords.x):
-		for y_index in range(tile_map.top_left_tile_coords.y, tile_map.bottom_right_tile_coords.y):
-			cells_lit_status[Vector2i(x_index, y_index)] = false
-
+func calculate_lit_cells() -> void:
 	var light_sources: Array[Node] = get_tree().get_nodes_in_group("light")
-
+	
+	lit_cells.clear()
 	for light_source in light_sources:
 		if light_source is LightSource:
 			var light_source_coords = calculate_tile_coords(light_source)
 			for light_shift in light_source.LightMap:
-				cells_lit_status[light_source_coords + light_shift] = true
+				lit_cells[light_source_coords + light_shift] = true
+	emit_signal("lit_cells_updated", lit_cells)
 
 func calculate_tile_coords(object: Node2D) -> Vector2i:
 	return tile_map.local_to_map(tile_map.to_local(object.global_position))

--- a/Scenes/Levels/Game.tscn
+++ b/Scenes/Levels/Game.tscn
@@ -44,4 +44,4 @@ position = Vector2(474, 314)
 stream = ExtResource("8_qk2x0")
 autoplay = true
 
-[connection signal="cells_lit_status_updated" from="." to="WorldTileMap" method="_on_cells_lit_status_updated"]
+[connection signal="lit_cells_updated" from="." to="WorldTileMap" method="_on_lit_cells_updated"]

--- a/Scenes/Levels/WorldTileMap.gd
+++ b/Scenes/Levels/WorldTileMap.gd
@@ -10,30 +10,26 @@ var terrain_set_main := 0
 var terrain_light := 0
 var terrain_darkness := 1
 
-var cells_lit_status: Dictionary = {}
-
-func _on_cells_lit_status_updated(new_cells_lit_status: Dictionary) -> void:
+func _on_lit_cells_updated(new_lit_cells: Dictionary) -> void:
 	var cells_to_lit: Array[Vector2i] = []
 	var cells_to_darken: Array[Vector2i] = []
 	
 	for cell_x in range(top_left_tile_coords.x, bottom_right_tile_coords.x):
 		for cell_y in range(top_left_tile_coords.y, bottom_right_tile_coords.y):
 			var cell_coords = Vector2i(cell_x, cell_y)
-			if new_cells_lit_status.has(cell_coords):
-				var should_be_lit = new_cells_lit_status[cell_coords]
-				var tile_data = get_cell_tile_data(darkness_layer, cell_coords)
+			var should_be_lit = new_lit_cells.has(cell_coords)
+			var tile_data = get_cell_tile_data(darkness_layer, cell_coords)
+			var is_lit: bool = not should_be_lit
+			if tile_data != null:
+				is_lit = tile_data.get_custom_data(custom_data_lit_layer)
 				
-				var is_lit: bool = not should_be_lit
-				if tile_data != null:
-					is_lit = tile_data.get_custom_data(custom_data_lit_layer)
-					
-				if should_be_lit and not is_lit:
-					cells_to_lit.append(cell_coords)
-				elif not should_be_lit and is_lit:
-					cells_to_darken.append(cell_coords)
-	
+			if should_be_lit and not is_lit:
+				cells_to_lit.append(cell_coords)
+			elif not should_be_lit and is_lit:
+				cells_to_darken.append(cell_coords)
+
 	if cells_to_darken.size() > 0:
 		set_cells_terrain_connect(darkness_layer, cells_to_darken, terrain_set_main, terrain_darkness, false)
-	
+
 	if cells_to_lit.size() > 0:
 		set_cells_terrain_connect(darkness_layer, cells_to_lit, terrain_set_main, terrain_light, false)


### PR DESCRIPTION
Game scene now has a more usable `lit_cells` dictionary, which only contains a list of lit cells. The keys are `Vector2i` and are cell coordinates, the value is always `true` and doesn't matter. To check if a cell is lit use:
```
lit_cells.has(cell_coordinates)
```

Game emits signal `lit_cells_updated` passing this dictionary of lit cells.

I'm thinking we can subscribe items to this signal when they are added to the scene, and they can despawn if they are on the ground and their coords are not in this dictionary.